### PR TITLE
Fix typical usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ No DTS parser/compiler is event considered since "dtc" is the official compiler,
 
 Typical usage is :
 ```
-from pyfdt import FdtBlobParse
+from pyfdt.pyfdt import FdtBlobParse
 with open("myfdt.dtb") as infile:
     dtb = FdtBlobParse(infile)
     print dtb.to_fdt().to_dts()


### PR DESCRIPTION
Update import statement in the typical usage shown in README.

Using the older import results in the following error:
Traceback (most recent call last):
  File "./test-fdt.py", line 8, in <module>
    dtb = pyfdt.FdtBlobParse(infile)
AttributeError: 'module' object has no attribute 'FdtBlobParse'